### PR TITLE
Add clickable agenda details and Amazon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
     .cart-link {
       color: var(--primary);
       text-decoration: none;
-      margin-right: 1rem;
+      margin-left: auto;
       font-size: 1.4rem;
     }
 
@@ -361,33 +361,33 @@
   <section id="consigli" class="tab-content">
     <!-- 3... +1 consigli di lettura per questa pausa estiva -->
     <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/Geopolitica-dellintelligenza-artificiale-Alessandro-Aresu-ebook/dp/B0DHV5T3T9/ref=sr_1_9?dib=eyJ2IjoiMSJ9.frXWBynOtlvhC6YHnyOediY9E-kVK1rb5oE6HJ-4TTD_AWyhdfC9Vejy3dOoo7BX7Dgxykbu_u7CAmzRuEtUR17WS1aeb155QcoTZ0ePligN8yJTQzrLlsTNtXpR4CSMY-EQZedamsaa1_fUL_FtQtFgouYLBm0FYvcUPsCze0YuZt70Y_9aYoF3yzssK6tYwO9Dw9EVUEOwZoNXAc7VBAbAnbIPk-XTmsdRxGiJC1w.jTJCjNLybGldIZBT7TzLsgoTYkrcliUcN2A9KeAw79A&dib_tag=se&qid=1753979940&s=books&sr=1-9" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>Geopolitica dell'intelligenza artificiale</h3>
         <p><em>Alessandro Aresu</em></p>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/Geopolitica-dellintelligenza-artificiale-Alessandro-Aresu-ebook/dp/B0DHV5T3T9/ref=sr_1_9?dib=eyJ2IjoiMSJ9.frXWBynOtlvhC6YHnyOediY9E-kVK1rb5oE6HJ-4TTD_AWyhdfC9Vejy3dOoo7BX7Dgxykbu_u7CAmzRuEtUR17WS1aeb155QcoTZ0ePligN8yJTQzrLlsTNtXpR4CSMY-EQZedamsaa1_fUL_FtQtFgouYLBm0FYvcUPsCze0YuZt70Y_9aYoF3yzssK6tYwO9Dw9EVUEOwZoNXAc7VBAbAnbIPk-XTmsdRxGiJC1w.jTJCjNLybGldIZBT7TzLsgoTYkrcliUcN2A9KeAw79A&dib_tag=se&qid=1753979940&s=books&sr=1-9" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
     <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/s?i=stripbooks&rh=n%3A15216215031&s=popularity-rank&fs=true&ref=lp_15216215031_sar" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>La scorciatoia. Come le macchine sono diventate intelligenti senza pensare in modo umano</h3>
         <p><em>Nello Cristianini</em></p>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/s?i=stripbooks&rh=n%3A15216215031&s=popularity-rank&fs=true&ref=lp_15216215031_sar" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
-        <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/Umano-poco-umano-Giuseppe-Girgenti/dp/8856694174/ref=sr_1_1?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dib=eyJ2IjoiMSJ9.nS-8wrKL1JFj4-D099eqEg.K1Uc6i41Lxy5V9GyInjWrtYG0ICBX-as4jTSOkzC3nk&dib_tag=se&keywords=crippa+intelligenza+artificiale&qid=1753980666&s=books&sr=1-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+   <section class="agenda-item">
       <div class="agenda-content">
         <h3>Umano, poco umano. Esercizi spirituali contro l'intelligenza artificiale</h3>
         <p><em>Mauro Crippa, Giuseppe Girgenti</em></p>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/Umano-poco-umano-Giuseppe-Girgenti/dp/8856694174/ref=sr_1_1?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dib=eyJ2IjoiMSJ9.nS-8wrKL1JFj4-D099eqEg.K1Uc6i41Lxy5V9GyInjWrtYG0ICBX-as4jTSOkzC3nk&dib_tag=se&keywords=crippa+intelligenza+artificiale&qid=1753980666&s=books&sr=1-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
     <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/Londa-che-verr%C3%A0-Mustafa-Suleyman-ebook/dp/B0CXCYJQRL/ref=sr_1_1?adgrpid=161911767569&dib=eyJ2IjoiMSJ9.UwKU8fdr6yhNqRTfhKHmo3IAvaqepXx96n9tb8Vul9ciiITffFxmNpV7bX9yDCRzF6XXHoim0EwcT6JBq_rGYW1chLhKubSy0-DzBIla0kxiRZCShBRQECC3zxXHrdvTeBiVRl7zA-AYDy7BhP6LOg.O8qmzNH-3FVRldewOpkhwR5HwAL3FRbwgTNWMtI64lU&dib_tag=se&hvadid=710724147533&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=10620017132028927798--&hvqmt=e&hvrand=10620017132028927798&hvtargid=kwd-2301754090518&hydadcr=28430_2518840&keywords=l%27onda+che+verr%C3%A0&mcid=ce17461b3b6630bd95c150e3cadb90fc&qid=1753978372&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>L'onda che verrà</h3>
         <p><em>Mustafa Suleyman, Michael Bhaskar</em></p>
         <p class="agenda-detail">Uno sguardo a come l'IA e le nuove tecnologie stanno trasformando il futuro.</p>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/Londa-che-verr%C3%A0-Mustafa-Suleyman-ebook/dp/B0CXCYJQRL/ref=sr_1_1?adgrpid=161911767569&dib=eyJ2IjoiMSJ9.UwKU8fdr6yhNqRTfhKHmo3IAvaqepXx96n9tb8Vul9ciiITffFxmNpV7bX9yDCRzF6XXHoim0EwcT6JBq_rGYW1chLhKubSy0-DzBIla0kxiRZCShBRQECC3zxXHrdvTeBiVRl7zA-AYDy7BhP6LOg.O8qmzNH-3FVRldewOpkhwR5HwAL3FRbwgTNWMtI64lU&dib_tag=se&hvadid=710724147533&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=10620017132028927798--&hvqmt=e&hvrand=10620017132028927798&hvtargid=kwd-2301754090518&hydadcr=28430_2518840&keywords=l%27onda+che+verr%C3%A0&mcid=ce17461b3b6630bd95c150e3cadb90fc&qid=1753978372&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
   </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
         <h3>Prompting Tips & Tricks</h3>
         <p class="time">50 min</p>
         <p><strong>Speaker:</strong> Team BCG-Reply</p>
-        <p class="agenda-detail"></p>Una sessione pratica guidata per sperimentare dal vivo l’utilizzo dei modelli generativi. I partecipanti potranno provare in prima persona tecniche di prompting su diversi scenari (scrittura, sintesi, ricerca, automazione), confrontare approcci, ricevere feedback immediato e scoprire come migliorare l’efficacia delle richieste ai modelli. L’obiettivo è rendere l’AI uno strumento quotidiano, concreto e potenziato dalla pratica.
+        <p class="agenda-detail">Una sessione pratica guidata per sperimentare dal vivo l’utilizzo dei modelli generativi. I partecipanti potranno provare in prima persona tecniche di prompting su diversi scenari (scrittura, sintesi, ricerca, automazione), confrontare approcci, ricevere feedback immediato e scoprire come migliorare l’efficacia delle richieste ai modelli. L’obiettivo è rendere l’AI uno strumento quotidiano, concreto e potenziato dalla pratica.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
         <h3>AI Generativa, dalle chat agli agenti</h3>
         <p class="time">40 min</p>
         <p><strong>Speaker:</strong> Antonio Faraldi</p>
-        <p class="agenda-detail">Panoramica sulle tecnologie generative e sui possibili utilizzi.</p>
+        <p class="agenda-detail">Boston Consulting Group ci guiderà in un’introduzione sull’evoluzione dell’intelligenza artificiale generativa: si partirà dalle chatbot testuali per arrivare ai nuovi “agenti AI”, sistemi capaci di pianificare, eseguire task complessi e interagire in autonomia con ambienti digitali. Verranno mostrati casi d’uso concreti e scenari applicativi rilevanti per i media e le aziende.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">

--- a/index.html
+++ b/index.html
@@ -65,10 +65,41 @@
       color: var(--primary);
     }
 
+    .tabs {
+      display: flex;
+      border-bottom: 3px solid var(--primary);
+      background: var(--accent);
+    }
+
+    .tab {
+      flex: 1;
+      padding: 1rem;
+      text-align: center;
+      cursor: pointer;
+      color: var(--light);
+      font-size: 1.1rem;
+      font-weight: 600;
+      background: var(--accent);
+      border: none;
+    }
+
+    .tab.active {
+      background: var(--primary);
+      color: var(--dark);
+    }
+
     main {
       max-width: 900px;
       margin: 0 auto;
       padding: 2rem 1rem;
+    }
+
+    .tab-content {
+      display: none;
+    }
+
+    .tab-content.active {
+      display: block;
     }
 
     .agenda-item {
@@ -82,6 +113,7 @@
       border-radius: 12px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, .4);
       transition: transform .3s ease, box-shadow .3s ease;
+      cursor: pointer;
     }
 
     .agenda-item:hover {
@@ -118,6 +150,22 @@
 
     .agenda-content p {
       margin: 0.2rem 0;
+    }
+
+    .agenda-detail {
+      display: none;
+      margin-top: 0.5rem;
+      font-size: 0.95rem;
+      color: #ccc;
+    }
+
+    .agenda-item.open .agenda-detail {
+      display: block;
+    }
+
+    .cart-link {
+      color: var(--primary);
+      text-decoration: none;
     }
 
     .agenda-logo img {
@@ -182,93 +230,154 @@
   <p>Sala Camana, 9:45 - 13:00</p>
 </header>
 
+<nav class="tabs">
+  <button class="tab active" data-tab="agenda">Agenda</button>
+  <button class="tab" data-tab="guide">Guide all'uso dell'IA</button>
+  <button class="tab" data-tab="consigli">Consigli di lettura</button>
+</nav>
+
 <main>
+  <section id="agenda" class="tab-content active">
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-handshake"></i></div>
+      <div class="agenda-content">
+        <h3>Welcome</h3>
+        <p class="time">15 min</p>
+        <p class="agenda-detail">Introduzione e saluti iniziali.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Logo">
+      </div>
+    </section>
 
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-handshake"></i></div>
-    <div class="agenda-content">
-      <h3>Welcome</h3>
-      <p class="time">15 min</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Logo">
-    </div>
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-rocket"></i></div>
+      <div class="agenda-content">
+        <h3>AI Generativa, dalle chat agli agenti</h3>
+        <p class="time">40 min</p>
+        <p><strong>Speaker:</strong> Antonio Faraldi</p>
+        <p class="agenda-detail">Panoramica sulle tecnologie generative e sui possibili utilizzi.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">
+      </div>
+    </section>
+
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-scale-balanced"></i></div>
+      <div class="agenda-content">
+        <h3>AI Act e primi elementi di “guard-railing” per l’Azienda</h3>
+        <p class="time">30 min</p>
+        <p><strong>Speaker:</strong> PWC</p>
+        <p class="agenda-detail">Illustrazione dei nuovi regolamenti europei e relative implicazioni.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
+      </div>
+    </section>
+
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-mug-saucer"></i></div>
+      <div class="agenda-content">
+        <h3>Coffee Break</h3>
+        <p class="time">15 min</p>
+        <p class="agenda-detail">Pausa con caffè e networking.</p>
+      </div>
+    </section>
+
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-lightbulb"></i></div>
+      <div class="agenda-content">
+        <h3>Programma <b>MedIAset</b></h3>
+        <p class="time">30 min</p>
+        <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
+        <p class="agenda-detail">Presentazione del programma interno di sperimentazione.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
+      </div>
+    </section>
+
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-wand-magic"></i></div>
+      <div class="agenda-content">
+        <h3>Prompting Tips & Tricks</h3>
+        <p class="time">50 min</p>
+        <p><strong>Speaker:</strong> Team BCG-Reply</p>
+        <p class="agenda-detail">Suggerimenti per creare prompt efficaci.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">
+      </div>
+    </section>
+
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-flag-checkered"></i></div>
+      <div class="agenda-content">
+        <h3>Fine lavori</h3>
+        <p class="time">10 min</p>
+        <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
+        <p class="agenda-detail">Conclusione della giornata e prossimi passi.</p>
+      </div>
+      <div class="agenda-logo">
+        <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Fine lavori">
+      </div>
+    </section>
   </section>
 
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-rocket"></i></div>
-    <div class="agenda-content">
-      <h3>AI Generativa, dalle chat agli agenti</h3>
-      <p class="time">40 min</p>
-      <p><strong>Speaker:</strong> Antonio Faraldi</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">
-    </div>
+  <section id="guide" class="tab-content">
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-book"></i></div>
+      <div class="agenda-content">
+        <h3>Guida all'uso di ChatGPT</h3>
+        <p><a class="download-link" href="https://aiworkshopmediaset.s3.amazonaws.com/Guida chatgpt 31.7  .pdf" download>Scarica PDF</a></p>
+      </div>
+    </section>
+    <section class="agenda-item">
+      <div class="icon"><i class="fas fa-book"></i></div>
+      <div class="agenda-content">
+        <h3>Guida “Prompting efficace”</h3>
+        <p><a class="download-link" href="https://aiworkshopmediaset.s3.amazonaws.com/esploriamo_il_mondo_dei_prompt.pdf" download>Scarica PDF</a></p>
+      </div>
+    </section>
   </section>
 
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-scale-balanced"></i></div>
-    <div class="agenda-content">
-      <h3>AI Act e primi elementi di “guard-railing” per l’Azienda</h3>
-      <p class="time">30 min</p>
-      <p><strong>Speaker:</strong> PWC</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
-    </div>
+  <section id="consigli" class="tab-content">
+    <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/s?k=AI+Superpowers+Kai-Fu+Lee" target="_blank"><i class="fas fa-cart-shopping"></i></a>
+      <div class="agenda-content">
+        <h3>AI Superpowers - Kai-Fu Lee</h3>
+      </div>
+    </section>
+    <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/s?k=Human+Compatible+Stuart+Russell" target="_blank"><i class="fas fa-cart-shopping"></i></a>
+      <div class="agenda-content">
+        <h3>Human Compatible - Stuart Russell</h3>
+      </div>
+    </section>
   </section>
-
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-mug-saucer"></i></div>
-    <div class="agenda-content">
-      <h3>Coffee Break</h3>
-      <p class="time">15 min</p>
-    </div>
-  </section>
-
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-lightbulb"></i></div>
-    <div class="agenda-content">
-      <h3>Programma <b>MedIAset</b></h3>
-      <p class="time">30 min</p>
-      <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
-    </div>
-  </section>
-
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-wand-magic"></i></div>
-    <div class="agenda-content">
-      <h3>Prompting Tips & Tricks</h3>
-      <p class="time">50 min</p>
-      <p><strong>Speaker:</strong> Team BCG-Reply</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">
-    </div>
-  </section>
-
-  <section class="agenda-item">
-    <div class="icon"><i class="fas fa-flag-checkered"></i></div>
-    <div class="agenda-content">
-      <h3>Fine lavori</h3>
-      <p class="time">10 min</p>
-      <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
-    </div>
-    <div class="agenda-logo">
-      <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Fine lavori">
-    </div>
-  </section>
-
 </main>
+
 <footer>
-  <a href="https://aiworkshopmediaset.s3.amazonaws.com/Guida chatgpt 31.7  .pdf" class="download-link" download>Scarica la guida all'uso di ChatGPT</a><br>
-  <a href="https://aiworkshopmediaset.s3.amazonaws.com/esploriamo_il_mondo_dei_prompt.pdf" class="download-link" download>Scarica la guida “Prompting efficace”</a><br>
   &copy; 2025 Mediaset – Direzione Tecnologie<br>
 </footer>
+
+<script>
+  document.querySelectorAll('.tab').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('.tab').forEach(function(b){ b.classList.remove('active'); });
+      document.querySelectorAll('.tab-content').forEach(function(tc){ tc.classList.remove('active'); });
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.add('active');
+    });
+  });
+
+  document.querySelectorAll('#agenda .agenda-item').forEach(function(item) {
+    item.addEventListener('click', function() {
+      item.classList.toggle('open');
+    });
+  });
+</script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
     .cart-link {
       color: var(--primary);
       text-decoration: none;
-      margin-left: auto;
+      margin-right: 1rem;
       font-size: 1.4rem;
     }
 
@@ -268,7 +268,7 @@
         <h3>AI Generativa, dalle chat agli agenti</h3>
         <p class="time">40 min</p>
         <p><strong>Speaker:</strong> Antonio Faraldi</p>
-        <p class="agenda-detail">Boston Consulting Group ci guiderà in un’introduzione sull’evoluzione dell’intelligenza artificiale generativa: si partirà dalle chatbot testuali per arrivare ai nuovi “agenti AI”, sistemi capaci di pianificare, eseguire task complessi e interagire in autonomia con ambienti digitali. Verranno mostrati casi d’uso concreti e scenari applicativi rilevanti per i media e le aziende.</p>
+        <p class="agenda-detail">Panoramica sulle tecnologie generative e sui possibili utilizzi.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">
@@ -282,7 +282,7 @@
         <h3>AI Act e primi elementi di “guard-railing” per l’Azienda</h3>
         <p class="time">30 min</p>
         <p><strong>Speaker:</strong> PWC</p>
-        <p class="agenda-detail">PWC porterà evidenza sugli effetti operativi derivanti dal nuovo regolamento europeo sull’intelligenza artificiale (AI Act), con focus sugli impatti organizzativi e sulle misure iniziali che le aziende, in particolare quelle del settore media e broadcasting, possono adottare per garantire un uso responsabile e conforme delle tecnologie AI.</p>
+        <p class="agenda-detail">Illustrazione dei nuovi regolamenti europei e relative implicazioni.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
@@ -305,7 +305,7 @@
         <h3>Programma <b>MedIAset</b></h3>
         <p class="time">30 min</p>
         <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
-        <p class="agenda-detail">Marcello e Luca descriveranno il programma aziendale di esplorazione e sperimentazione dell'intelligenza artificiale generativa. In particolare si soffermeranno sui tre ambiti principali del programma: identificazione dei principi e delle linee guida aziendali di utilizzo della GEN-AI, sperimentazione di strumenti a supporto della produttività individuale, Identificazione e implementazioni di use case verticali per la nostra industry.</p>
+        <p class="agenda-detail">Presentazione del programma interno di sperimentazione.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
@@ -319,7 +319,7 @@
         <h3>Prompting Tips & Tricks</h3>
         <p class="time">50 min</p>
         <p><strong>Speaker:</strong> Team BCG-Reply</p>
-        <p class="agenda-detail">Una sessione pratica guidata per sperimentare dal vivo l’utilizzo dei modelli generativi. I partecipanti potranno provare in prima persona tecniche di prompting su diversi scenari (scrittura, sintesi, ricerca, automazione), confrontare approcci, ricevere feedback immediato e scoprire come migliorare l’efficacia delle richieste ai modelli. L’obiettivo è rendere l’AI uno strumento quotidiano, concreto e potenziato dalla pratica.</p>
+        <p class="agenda-detail">Suggerimenti per creare prompt efficaci.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">
@@ -359,19 +359,35 @@
   </section>
 
   <section id="consigli" class="tab-content">
+    <!-- 3... +1 consigli di lettura per questa pausa estiva -->
     <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/Geopolitica-dellintelligenza-artificiale-Alessandro-Aresu-ebook/dp/B0DHV5T3T9/ref=sr_1_9?dib=eyJ2IjoiMSJ9.frXWBynOtlvhC6YHnyOediY9E-kVK1rb5oE6HJ-4TTD_AWyhdfC9Vejy3dOoo7BX7Dgxykbu_u7CAmzRuEtUR17WS1aeb155QcoTZ0ePligN8yJTQzrLlsTNtXpR4CSMY-EQZedamsaa1_fUL_FtQtFgouYLBm0FYvcUPsCze0YuZt70Y_9aYoF3yzssK6tYwO9Dw9EVUEOwZoNXAc7VBAbAnbIPk-XTmsdRxGiJC1w.jTJCjNLybGldIZBT7TzLsgoTYkrcliUcN2A9KeAw79A&dib_tag=se&qid=1753979940&s=books&sr=1-9" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+      <div class="agenda-content">
+        <h3>Geopolitica dell'intelligenza artificiale</h3>
+        <p><em>Alessandro Aresu</em></p>
+      </div>
+    </section>
+    <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/s?i=stripbooks&rh=n%3A15216215031&s=popularity-rank&fs=true&ref=lp_15216215031_sar" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+      <div class="agenda-content">
+        <h3>LA SCORCIATOIA. Come le macchine sono diventate intelligenti senza pensare in modo umano</h3>
+        <p><em>Nello Cristianini</em></p>
+      </div>
+    </section>
+    <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/Londa-che-verr%C3%A0-Mustafa-Suleyman-ebook/dp/B0CXCYJQRL/ref=sr_1_1?adgrpid=161911767569&dib=eyJ2IjoiMSJ9.UwKU8fdr6yhNqRTfhKHmo3IAvaqepXx96n9tb8Vul9ciiITffFxmNpV7bX9yDCRzF6XXHoim0EwcT6JBq_rGYW1chLhKubSy0-DzBIla0kxiRZCShBRQECC3zxXHrdvTeBiVRl7zA-AYDy7BhP6LOg.O8qmzNH-3FVRldewOpkhwR5HwAL3FRbwgTNWMtI64lU&dib_tag=se&hvadid=710724147533&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=10620017132028927798--&hvqmt=e&hvrand=10620017132028927798&hvtargid=kwd-2301754090518&hydadcr=28430_2518840&keywords=l%27onda+che+verr%C3%A0&mcid=ce17461b3b6630bd95c150e3cadb90fc&qid=1753978372&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>L'onda che verrà</h3>
         <p><em>Mustafa Suleyman, Michael Bhaskar</em></p>
         <p class="agenda-detail">Uno sguardo a come l'IA e le nuove tecnologie stanno trasformando il futuro.</p>
       </div>
-      <a class="cart-link icon" href="https://www.amazon.it/Londa-che-verr%C3%A0-Mustafa-Suleyman-ebook/dp/B0CXCYJQRL/ref=sr_1_1?adgrpid=161911767569&dib=eyJ2IjoiMSJ9.UwKU8fdr6yhNqRTfhKHmo3IAvaqepXx96n9tb8Vul9ciiITffFxmNpV7bX9yDCRzF6XXHoim0EwcT6JBq_rGYW1chLhKubSy0-DzBIla0kxiRZCShBRQECC3zxXHrdvTeBiVRl7zA-AYDy7BhP6LOg.O8qmzNH-3FVRldewOpkhwR5HwAL3FRbwgTNWMtI64lU&dib_tag=se&hvadid=710724147533&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=10620017132028927798--&hvqmt=e&hvrand=10620017132028927798&hvtargid=kwd-2301754090518&hydadcr=28430_2518840&keywords=l%27onda+che+verr%C3%A0&mcid=ce17461b3b6630bd95c150e3cadb90fc&qid=1753978372&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
     <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/Umano-poco-umano-Giuseppe-Girgenti/dp/8856694174/ref=sr_1_1?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dib=eyJ2IjoiMSJ9.nS-8wrKL1JFj4-D099eqEg.K1Uc6i41Lxy5V9GyInjWrtYG0ICBX-as4jTSOkzC3nk&dib_tag=se&keywords=crippa+intelligenza+artificiale&qid=1753980666&s=books&sr=1-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
-        <h3>Human Compatible - Stuart Russell</h3>
+        <h3>Umano, poco umano. Esercizi spirituali contro l'intelligenza artificiale</h3>
+        <p><em>Mauro Crippa, Giuseppe Girgenti</em></p>
       </div>
-      <a class="cart-link icon" href="https://www.amazon.it/s?k=Human+Compatible+Stuart+Russell" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
   </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -370,8 +370,15 @@
     <section class="agenda-item">
       <a class="cart-link icon" href="https://www.amazon.it/s?i=stripbooks&rh=n%3A15216215031&s=popularity-rank&fs=true&ref=lp_15216215031_sar" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
-        <h3>LA SCORCIATOIA. Come le macchine sono diventate intelligenti senza pensare in modo umano</h3>
+        <h3>La scorciatoia. Come le macchine sono diventate intelligenti senza pensare in modo umano</h3>
         <p><em>Nello Cristianini</em></p>
+      </div>
+    </section>
+        <section class="agenda-item">
+      <a class="cart-link icon" href="https://www.amazon.it/Umano-poco-umano-Giuseppe-Girgenti/dp/8856694174/ref=sr_1_1?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dib=eyJ2IjoiMSJ9.nS-8wrKL1JFj4-D099eqEg.K1Uc6i41Lxy5V9GyInjWrtYG0ICBX-as4jTSOkzC3nk&dib_tag=se&keywords=crippa+intelligenza+artificiale&qid=1753980666&s=books&sr=1-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+      <div class="agenda-content">
+        <h3>Umano, poco umano. Esercizi spirituali contro l'intelligenza artificiale</h3>
+        <p><em>Mauro Crippa, Giuseppe Girgenti</em></p>
       </div>
     </section>
     <section class="agenda-item">
@@ -380,13 +387,6 @@
         <h3>L'onda che verrà</h3>
         <p><em>Mustafa Suleyman, Michael Bhaskar</em></p>
         <p class="agenda-detail">Uno sguardo a come l'IA e le nuove tecnologie stanno trasformando il futuro.</p>
-      </div>
-    </section>
-    <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/Umano-poco-umano-Giuseppe-Girgenti/dp/8856694174/ref=sr_1_1?__mk_it_IT=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dib=eyJ2IjoiMSJ9.nS-8wrKL1JFj4-D099eqEg.K1Uc6i41Lxy5V9GyInjWrtYG0ICBX-as4jTSOkzC3nk&dib_tag=se&keywords=crippa+intelligenza+artificiale&qid=1753980666&s=books&sr=1-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
-      <div class="agenda-content">
-        <h3>Umano, poco umano. Esercizi spirituali contro l'intelligenza artificiale</h3>
-        <p><em>Mauro Crippa, Giuseppe Girgenti</em></p>
       </div>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
         <h3>AI Act e primi elementi di “guard-railing” per l’Azienda</h3>
         <p class="time">30 min</p>
         <p><strong>Speaker:</strong> PWC</p>
-        <p class="agenda-detail">Illustrazione dei nuovi regolamenti europei e relative implicazioni.</p>
+        <p class="agenda-detail">PWC porterà evidenza sugli effetti operativi derivanti dal nuovo regolamento europeo sull’intelligenza artificiale (AI Act), con focus sugli impatti organizzativi e sulle misure iniziali che le aziende, in particolare quelle del settore media e broadcasting, possono adottare per garantire un uso responsabile e conforme delle tecnologie AI.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
@@ -305,7 +305,7 @@
         <h3>Programma <b>MedIAset</b></h3>
         <p class="time">30 min</p>
         <p><strong>Speaker:</strong> Marcello Galli, Luca Poloni</p>
-        <p class="agenda-detail">Presentazione del programma interno di sperimentazione.</p>
+        <p class="agenda-detail">Marcello e Luca descriveranno il programma aziendale di esplorazione e sperimentazione dell'intelligenza artificiale generativa. In particolare si soffermeranno sui tre ambiti principali del programma: identificazione dei principi e delle linee guida aziendali di utilizzo della GEN-AI, sperimentazione di strumenti a supporto della produttività individuale, Identificazione e implementazioni di use case verticali per la nostra industry.</p>
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
@@ -319,7 +319,7 @@
         <h3>Prompting Tips & Tricks</h3>
         <p class="time">50 min</p>
         <p><strong>Speaker:</strong> Team BCG-Reply</p>
-        <p class="agenda-detail">Suggerimenti per creare prompt efficaci.</p>
+        <p class="agenda-detail"></p>Una sessione pratica guidata per sperimentare dal vivo l’utilizzo dei modelli generativi. I partecipanti potranno provare in prima persona tecniche di prompting su diversi scenari (scrittura, sintesi, ricerca, automazione), confrontare approcci, ricevere feedback immediato e scoprire come migliorare l’efficacia delle richieste ai modelli. L’obiettivo è rendere l’AI uno strumento quotidiano, concreto e potenziato dalla pratica.
       </div>
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">

--- a/index.html
+++ b/index.html
@@ -81,6 +81,11 @@
       font-weight: 600;
       background: var(--accent);
       border: none;
+      border-right: 2px solid var(--light);
+    }
+
+    .tab:last-child {
+      border-right: none;
     }
 
     .tab.active {
@@ -164,13 +169,8 @@
 
     .toggle {
       margin-left: auto;
-      font-size: 1.2rem;
+      font-size: 1.5rem;
       color: var(--primary);
-      transition: transform .3s ease;
-    }
-
-    .agenda-item.open .toggle {
-      transform: rotate(90deg);
     }
 
     .cart-link {
@@ -260,7 +260,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Logo">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -274,7 +274,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -288,7 +288,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -298,7 +298,7 @@
         <p class="time">15 min</p>
         <p class="agenda-detail">Pausa con caffè e networking.</p>
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -312,7 +312,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -326,7 +326,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -340,7 +340,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Fine lavori">
       </div>
-      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
+      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
   </section>
 
@@ -394,6 +394,14 @@
   document.querySelectorAll('#agenda .agenda-item').forEach(function(item) {
     item.addEventListener('click', function() {
       item.classList.toggle('open');
+      var icon = item.querySelector('.toggle i');
+      if (item.classList.contains('open')) {
+        icon.classList.remove('fa-circle-plus');
+        icon.classList.add('fa-circle-minus');
+      } else {
+        icon.classList.remove('fa-circle-minus');
+        icon.classList.add('fa-circle-plus');
+      }
     });
   });
 </script>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,6 @@
 
     .agenda-item {
       display: flex;
-      justify-content: space-between;
       align-items: center;
       gap: 1.5rem;
       margin-bottom: 1.75rem;
@@ -163,9 +162,22 @@
       display: block;
     }
 
+    .toggle {
+      margin-left: auto;
+      font-size: 1.2rem;
+      color: var(--primary);
+      transition: transform .3s ease;
+    }
+
+    .agenda-item.open .toggle {
+      transform: rotate(90deg);
+    }
+
     .cart-link {
       color: var(--primary);
       text-decoration: none;
+      margin-left: auto;
+      font-size: 1.4rem;
     }
 
     .agenda-logo img {
@@ -248,6 +260,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Logo">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -261,6 +274,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/BCG_Corporate_Logo.png" alt="BCG">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -274,6 +288,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/pwc.png" alt="PwC">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -283,6 +298,7 @@
         <p class="time">15 min</p>
         <p class="agenda-detail">Pausa con caffè e networking.</p>
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -296,6 +312,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="MedIAset">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -309,6 +326,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/bcgreply.png" alt="BCG Reply">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -322,6 +340,7 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Fine lavori">
       </div>
+      <div class="toggle"><i class="fas fa-chevron-right"></i></div>
     </section>
   </section>
 
@@ -344,16 +363,16 @@
 
   <section id="consigli" class="tab-content">
     <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/s?k=AI+Superpowers+Kai-Fu+Lee" target="_blank"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>AI Superpowers - Kai-Fu Lee</h3>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/s?k=AI+Superpowers+Kai-Fu+Lee" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
     <section class="agenda-item">
-      <a class="cart-link icon" href="https://www.amazon.it/s?k=Human+Compatible+Stuart+Russell" target="_blank"><i class="fas fa-cart-shopping"></i></a>
       <div class="agenda-content">
         <h3>Human Compatible - Stuart Russell</h3>
       </div>
+      <a class="cart-link icon" href="https://www.amazon.it/s?k=Human+Compatible+Stuart+Russell" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
   </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -260,7 +260,6 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Logo">
       </div>
-      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -298,7 +297,6 @@
         <p class="time">15 min</p>
         <p class="agenda-detail">Pausa con caffè e networking.</p>
       </div>
-      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
 
     <section class="agenda-item">
@@ -340,7 +338,6 @@
       <div class="agenda-logo">
         <img src="https://aiworkshopmediaset.s3.amazonaws.com/mediaset_logo.jpeg" alt="Fine lavori">
       </div>
-      <div class="toggle"><i class="fas fa-circle-plus"></i></div>
     </section>
   </section>
 
@@ -364,9 +361,11 @@
   <section id="consigli" class="tab-content">
     <section class="agenda-item">
       <div class="agenda-content">
-        <h3>AI Superpowers - Kai-Fu Lee</h3>
+        <h3>L'onda che verrà</h3>
+        <p><em>Mustafa Suleyman, Michael Bhaskar</em></p>
+        <p class="agenda-detail">Uno sguardo a come l'IA e le nuove tecnologie stanno trasformando il futuro.</p>
       </div>
-      <a class="cart-link icon" href="https://www.amazon.it/s?k=AI+Superpowers+Kai-Fu+Lee" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+      <a class="cart-link icon" href="https://www.amazon.it/Londa-che-verr%C3%A0-Mustafa-Suleyman-ebook/dp/B0CXCYJQRL/ref=sr_1_1?adgrpid=161911767569&dib=eyJ2IjoiMSJ9.UwKU8fdr6yhNqRTfhKHmo3IAvaqepXx96n9tb8Vul9ciiITffFxmNpV7bX9yDCRzF6XXHoim0EwcT6JBq_rGYW1chLhKubSy0-DzBIla0kxiRZCShBRQECC3zxXHrdvTeBiVRl7zA-AYDy7BhP6LOg.O8qmzNH-3FVRldewOpkhwR5HwAL3FRbwgTNWMtI64lU&dib_tag=se&hvadid=710724147533&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=10620017132028927798--&hvqmt=e&hvrand=10620017132028927798&hvtargid=kwd-2301754090518&hydadcr=28430_2518840&keywords=l%27onda+che+verr%C3%A0&mcid=ce17461b3b6630bd95c150e3cadb90fc&qid=1753978372&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
     <section class="agenda-item">
       <div class="agenda-content">
@@ -395,12 +394,14 @@
     item.addEventListener('click', function() {
       item.classList.toggle('open');
       var icon = item.querySelector('.toggle i');
-      if (item.classList.contains('open')) {
-        icon.classList.remove('fa-circle-plus');
-        icon.classList.add('fa-circle-minus');
-      } else {
-        icon.classList.remove('fa-circle-minus');
-        icon.classList.add('fa-circle-plus');
+      if (icon) {
+        if (item.classList.contains('open')) {
+          icon.classList.remove('fa-circle-plus');
+          icon.classList.add('fa-circle-minus');
+        } else {
+          icon.classList.remove('fa-circle-minus');
+          icon.classList.add('fa-circle-plus');
+        }
       }
     });
   });

--- a/index.html
+++ b/index.html
@@ -231,6 +231,14 @@
     .download-link:hover {
       text-decoration: underline;
     }
+
+    .reading-intro {
+      text-align: center;
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin: 1.5rem 0;
+      color: var(--primary);
+    }
   </style>
 </head>
 <body>
@@ -360,6 +368,7 @@
 
   <section id="consigli" class="tab-content">
     <!-- 3... +1 consigli di lettura per questa pausa estiva -->
+    <p class="reading-intro">3... +1 consigli di lettura per questa pausa estiva</p>
     <section class="agenda-item">
       <div class="agenda-content">
         <h3>Geopolitica dell'intelligenza artificiale</h3>
@@ -372,9 +381,9 @@
         <h3>La scorciatoia. Come le macchine sono diventate intelligenti senza pensare in modo umano</h3>
         <p><em>Nello Cristianini</em></p>
       </div>
-      <a class="cart-link icon" href="https://www.amazon.it/s?i=stripbooks&rh=n%3A15216215031&s=popularity-rank&fs=true&ref=lp_15216215031_sar" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
+      <a class="cart-link icon" href="https://www.amazon.it/SCORCIATOIA-macchine-diventate-intelligenti-pensare/dp/8815299831/ref=sr_1_1?adgrpid=151677336674&dib=eyJ2IjoiMSJ9.2hXHE7_G1HtUGHt9KCwG1pIYzECDcOUaAh8bqWJg_PSzOwDYy9HPt8YmA6iXtEkRQcWaMGUFzJciBxCg0dHwkMk9x3bMTb1OAypqUz6Idtwys5yCjrWQhmagzsE_w5wmbe9pknRDcSsUlOY44ZCbNA.uBdNNFGdW3MFIwV4axrDyAc8Pno_AqTP1pr5VnZfceo&dib_tag=se&hvadid=657061025997&hvdev=c&hvexpln=0&hvlocphy=9198639&hvnetw=g&hvocijid=17873138549297888273--&hvqmt=e&hvrand=17873138549297888273&hvtargid=kwd-2061178548210&hydadcr=28399_2397239&keywords=cristianini+la+scorciatoia&mcid=05c2fd31c8ad3daab4a9b381d2113ec5&qid=1753981849&sr=8-1" target="_blank" aria-label="Acquista su Amazon"><i class="fas fa-cart-shopping"></i></a>
     </section>
-   <section class="agenda-item">
+    <section class="agenda-item">
       <div class="agenda-content">
         <h3>Umano, poco umano. Esercizi spirituali contro l'intelligenza artificiale</h3>
         <p><em>Mauro Crippa, Giuseppe Girgenti</em></p>


### PR DESCRIPTION
## Summary
- make agenda blocks clickable and reveal details on click
- hide details with new `.agenda-detail` class
- add Amazon cart links next to recommended books
- JS updates to toggle agenda details

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688b885bb98c8320bb44dd141587b631